### PR TITLE
Added subdirectory parsing

### DIFF
--- a/patch.js
+++ b/patch.js
@@ -15,6 +15,9 @@ var modPath = function(tarball, currentHost) {
     if (h.port) {
         u.port = h.port;
     }
+    if(h.pathname != '/') {
+        u.pathname = h.pathname + u.pathname
+    }
     return url.format(u);
 };
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -55,12 +55,28 @@ var tests = {
             assert.equal(d, 'http://registry.davglass.com/foo/-/foo-1.0.1.tar.gz');
         }
     },
+    'should parse good url with http and subdirectory': {
+        topic: function() {
+            return patch.url(tarball, 'http://registry.davglass.com/subdir');
+        },
+        'and return valid info': function(d) {
+            assert.equal(d, 'http://registry.davglass.com/subdir/foo/-/foo-1.0.1.tar.gz');
+        }
+    },
     'should parse good url with https': {
         topic: function() {
             return patch.url(tarball, 'https://registry.davglass.com');
         },
         'and return valid info': function(d) {
             assert.equal(d, 'https://registry.davglass.com/foo/-/foo-1.0.1.tar.gz');
+        }
+    },
+    'should parse good url with https and subdirectory': {
+        topic: function() {
+            return patch.url(tarball, 'https://registry.davglass.com/subdir');
+        },
+        'and return valid info': function(d) {
+            assert.equal(d, 'https://registry.davglass.com/subdir/foo/-/foo-1.0.1.tar.gz');
         }
     },
     'should parse good url with no protocol': {
@@ -71,12 +87,28 @@ var tests = {
             assert.equal(d, 'http://registry.davglass.com/foo/-/foo-1.0.1.tar.gz');
         }
     },
+    'should parse good url with no protocol and subdirectory': {
+        topic: function() {
+            return patch.url(tarball, 'http://registry.davglass.com/subdir');
+        },
+        'and return valid info': function(d) {
+            assert.equal(d, 'http://registry.davglass.com/subdir/foo/-/foo-1.0.1.tar.gz');
+        }
+    },
     'should parse good url with port': {
         topic: function() {
             return patch.url(tarball, 'http://registry.davglass.com:8080/');
         },
         'and return valid info': function(d) {
             assert.equal(d, 'http://registry.davglass.com:8080/foo/-/foo-1.0.1.tar.gz');
+        }
+    },
+    'should parse good url with port and subdirectory': {
+        topic: function() {
+            return patch.url(tarball, 'http://registry.davglass.com:8080/subdir');
+        },
+        'and return valid info': function(d) {
+            assert.equal(d, 'http://registry.davglass.com:8080/subdir/foo/-/foo-1.0.1.tar.gz');
         }
     },
     'should parse simple json': {


### PR DESCRIPTION
This permits the use of subdirectories in the package uri replacement.
Use cases might include running more than one static mirror on the
same host (pypi adjacent to npm).
